### PR TITLE
Fix UV measurement and provide raw output

### DIFF
--- a/examples/readUV/readUV.ino
+++ b/examples/readUV/readUV.ino
@@ -33,7 +33,7 @@ void setup()
 void loop()
 { 
   int uv_rawdata = faboUV.readUVraw();
-  float uv_index = uv_rawdata / 100;
+  float uv_index = uv_rawdata / 100.;
   int ir = faboUV.readIR();
   int visible = faboUV.readVisible();
   

--- a/examples/readUV/readUV.ino
+++ b/examples/readUV/readUV.ino
@@ -32,8 +32,8 @@ void setup()
 
 void loop()
 { 
-  int uv_rawdata = faboUV.readUV();
-  int uv_index = uv_rawdata / 100;
+  int uv_rawdata = faboUV.readUVraw();
+  float uv_index = uv_rawdata / 100;
   int ir = faboUV.readIR();
   int visible = faboUV.readVisible();
   

--- a/src/FaBoUV_Si1132.cpp
+++ b/src/FaBoUV_Si1132.cpp
@@ -68,7 +68,7 @@ void FaBoUV::configuration()
   writeI2c(SI1132_UCOEF3_REG, 0x00);
 
   // SET PARAM_WR(Chiplist)
-  writeI2c(SI1132_PARAM_WR_REG, SI1132_EN_UV|SI1132_EN_AUX|SI1132_EN_ALS_IR|SI1132_EN_ALS_VIS);
+  writeI2c(SI1132_PARAM_WR_REG, SI1132_EN_UV|SI1132_EN_ALS_IR|SI1132_EN_ALS_VIS);
   // COMMAND(Set Chiplist)
   writeI2c(SI1132_COMMAND_REG, SI1132_PARAM_SET|SI1132_CHIPLIST_PARAM_OFFSET);
 
@@ -131,18 +131,25 @@ void FaBoUV::reset()
 }
 
 /**
+ @brief Read UV raw
+ @param [out] uv rawdata
+*/
+uint16_t FaBoUV::readUVraw()
+{
+  uint8_t buffer[2];
+
+  readI2c(SI1132_AUX_DATA_REG, 2, buffer);
+  uint16_t uv = (((uint16_t)buffer[1])<<8) | (uint16_t)buffer[0];
+  return uv;
+}
+
+/**
  @brief Read UV
  @param [out] uv rawdata (rawdata/100 -> UV INDEX)
 */
 uint16_t FaBoUV::readUV()
 {
-  uint16_t uv_index;
-  uint8_t buffer[2];
-
-  readI2c(SI1132_AUX_DATA_REG, 2, buffer);
-  uv_index = (((uint16_t)buffer[1])<<8) | (uint16_t)buffer[0];
-  Serial.println(uv_index);
-  uint16_t uv = uv_index/100;
+  uint16_t uv = readUVraw()/100;
   return uv;
 }
 

--- a/src/FaBoUV_Si1132.h
+++ b/src/FaBoUV_Si1132.h
@@ -144,6 +144,7 @@ public:
 	bool searchDevice(void);
 	void configuration(void);
 	void reset(void);
+	uint16_t readUVraw(void);
 	uint16_t readUV(void);
 	uint16_t readIR(void);
 	uint16_t readVisible(void);


### PR DESCRIPTION
- The AUX register didn't need to be enabled, otherwise it was clashing with UV output and providing large spurious values.
- Also, integer division by 100 was taking away some precision from the UV output, so there is a new function called readUVraw(). (I decided to keep readUV as-is to guarantee backward compatibility)
- Also fixes #1 by removing debug UV serial print.

Thanks for this very useful library! :)